### PR TITLE
Clamped scaling to avoid negative values.

### DIFF
--- a/Project/Assets/BanditEnvironment.cs
+++ b/Project/Assets/BanditEnvironment.cs
@@ -141,9 +141,9 @@ public class BanditEnvironment : MonoBehaviour {
 			GameObject valueSphere = (GameObject)GameObject.Instantiate (Resources.Load ("value"));
 			valueSphere.transform.position = new Vector3 ((i+1) * (12.5f / (total-1)) - ((12.5f / (total-1))*total)/2, 3f, 1.5f);
 			float inflation = 2 * agent.value_table [state][i] + 0.25f;
-			if (inflation > 2.5f) {
-				inflation = 2.5f;
-			}
+			
+			inflation = Mathf.Clamp(inflation, 0, 2.5f);
+			
 			valueSphere.transform.localScale = new Vector3 (inflation, inflation, inflation);
 			estimatedValues.Add (valueSphere);
 


### PR DESCRIPTION
As  the value table can contain negative numbers, the scaling of the 'estimate' green bubble should be bounded to keep >=0.  This avoids having a broken bubble size for the 'estimated probability' representation when comparing to the 'true probability' bubble representation.

How to reproduce the bug: select initial settings (possible to de-activate optimism for faster bug appearance): after shrinking, the green bubble of the lower probability shelf will increase when negative reward is encountered.
See Issue #2 for more details.